### PR TITLE
Add support for filtering on platform

### DIFF
--- a/src/components/filterComponent.vue
+++ b/src/components/filterComponent.vue
@@ -23,6 +23,25 @@
                     </div>
                 </div>
             </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header">
+                    <button class="accordion-button px-0 shadow-none" type="button" data-bs-toggle="collapse"
+                            data-bs-target="#collapseType" aria-expanded="true" aria-controls="collapseType">
+                        <small>Platform</small>
+                    </button>
+                </h2>
+                <div id="collapseType" class="accordion-collapse collapse show px-0">
+                    <div class="accordion-body px-0">
+                        <div class="form-check" v-for="(count, platform, idx) in groupedPlatforms" :key="idx">
+                            <input class="form-check-input" type="checkbox" :id="'platform-' + platform" :value="platform" name="platform"
+                                   @change="contentStore.filter()" v-model="filters.platform">
+                            <label class="form-check-label text-capitalize" :for="'platform-' + platform">
+                                {{platform}} ({{ count }})
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            </div>
             <!-- date -->
             <div class="accordion-item">
                 <h2 class="accordion-header">
@@ -144,7 +163,7 @@ import {storeToRefs} from "pinia";
 import {computed, ref} from "vue";
 
 const contentStore = useContentStore()
-const {filters, groupedActivities, groupedTypes, groupedDates} = storeToRefs(contentStore)
+const {filters, groupedActivities, groupedTypes, groupedPlatforms, groupedDates} = storeToRefs(contentStore)
 
 const f_term = ref('')
 const f_activities = computed(() => {

--- a/src/stores/content.js
+++ b/src/stores/content.js
@@ -20,6 +20,7 @@ export const useContentStore = defineStore('content', {
         sortOptionSeries: 'newOld',
         filters: {
             type: [],
+            platform: [],
             free: false,
             vodOnly: false,
             date: {
@@ -76,7 +77,7 @@ export const useContentStore = defineStore('content', {
             })
         },
         groupedTypes() {
-            return this.content.filter(item => this.f_paywall(item) && this.f_vod(item) && this.f_date(item) && this.f_duration(item) && this.f_activity(item)).reduce((p, c) => {
+            return this.content.filter(item => this.f_platform(item) && this.f_paywall(item) && this.f_vod(item) && this.f_date(item) && this.f_duration(item) && this.f_activity(item)).reduce((p, c) => {
                 const type = c.type;
                 if (!p.hasOwnProperty(type)) {
                     p[type] = 0;
@@ -85,8 +86,24 @@ export const useContentStore = defineStore('content', {
                 return p;
             }, {});
         },
+        groupedPlatforms() {
+            return this.content.filter(item => this.f_type(item) && this.f_paywall(item) && this.f_vod(item) && this.f_date(item) && this.f_duration(item) && this.f_activity(item)).reduce((p, c) => {
+                // Making this dynamic would require a change in the JSON to give the platform property a unique prefix/suffix.
+                // Currently _id is also used by twitchtracker_id.
+                // Alternatively it could be put inside a platforms array.
+                // E.g. platforms: [{ name: 'twitch', id: '1234' }, { name: 'youtube', id: '5678' }]
+                for (const platform of ['twitch', 'youtube']) {
+                    if (!c.hasOwnProperty(platform + '_id')) continue
+                    if (!p.hasOwnProperty(platform)) {
+                        p[platform] = 0;
+                    }
+                    p[platform]++;
+                }
+                return p;
+            }, {});
+        },
         groupedDates() {
-            return this.content.filter(item => this.f_type(item) && this.f_paywall(item) && this.f_vod(item) && this.f_duration(item) && this.f_activity(item)).reduce((p, c) => {
+            return this.content.filter(item => this.f_type(item) && this.f_platform(item) && this.f_paywall(item) && this.f_vod(item) && this.f_duration(item) && this.f_activity(item)).reduce((p, c) => {
                 p['alle']++
                 if (this.checkSingleDate(c, 3)) p['< 3 maanden']++
                 if (this.checkSingleDate(c, 6)) p['< 6 maanden']++
@@ -95,7 +112,7 @@ export const useContentStore = defineStore('content', {
             }, { 'alle': 0,'< 3 maanden': 0, '< 6 maanden': 0, '< 12 maanden': 0});
         },
         groupedActivities() {
-            return this.content.filter(item => this.f_type(item) && this.f_paywall(item) && this.f_vod(item) && this.f_date(item) && this.f_duration(item)).reduce((p, c) => {
+            return this.content.filter(item => this.f_type(item) && this.f_platform(item) && this.f_paywall(item) && this.f_vod(item) && this.f_date(item) && this.f_duration(item)).reduce((p, c) => {
                 const act = c['activity'] || c['activities'];
                 if (act === undefined) return p
                 if (Array.isArray(act)) {
@@ -228,7 +245,7 @@ export const useContentStore = defineStore('content', {
             })
 
             // filter content
-            data = data.filter(item => this.f_type(item) && this.f_paywall(item) && this.f_vod(item) && this.f_date(item) && this.f_duration(item) && this.f_activity(item))
+            data = data.filter(item => this.f_type(item) && this.f_platform(item) && this.f_paywall(item) && this.f_vod(item) && this.f_date(item) && this.f_duration(item) && this.f_activity(item))
 
             for (const item of data) {
                 this.filteredData.push(item)
@@ -241,6 +258,14 @@ export const useContentStore = defineStore('content', {
          */
         f_type(item) {
             return !this.filters.type.length || this.filters.type.includes(item.type)
+        },
+        /**
+         * Filter items by platform
+         * @param item
+         * @returns {boolean|*}
+         */
+        f_platform(item) {
+            return !this.filters.platform.length || this.filters.platform.some(platform => item[platform + "_id"]);
         },
         /**
          * Filter item by paywall
@@ -419,6 +444,7 @@ export const useContentStore = defineStore('content', {
         },
         setFilterFromQuery(urlParams) {
             if(urlParams.getAll('type')) this.filters.type = urlParams.getAll('type')
+            if(urlParams.getAll('platform')) this.filters.platform = urlParams.getAll('platform')
             if(urlParams.get('free')) this.filters.free = urlParams.get('free')
             if(urlParams.get('vodOnly')) this.filters.vodOnly = urlParams.get('vodOnly')
             if(urlParams.get('date_range')) this.filters.date.range = urlParams.get('date_range')
@@ -430,8 +456,9 @@ export const useContentStore = defineStore('content', {
         },
         updateUrl() {
             const types = this.filters.type.length ? this.filters.type.map(t => ['type', t]) : []
+            const platforms = this.filters.platform.length ? this.filters.platform.map(t => ['platform', t]) : []
             const acts = this.filters.activity.length ? this.filters.activity.map(t => ['activity', t]) : []
-            let search = new URLSearchParams(types.concat(acts))
+            let search = new URLSearchParams(types.concat(acts).concat(platforms))
             if (this.filters.free)
                 search.append('free', this.filters.free)
             if (this.filters.vodOnly)


### PR DESCRIPTION
Het mooiste zou zijn als dit dynamisch is, maar gezien we de suffix `_id` ook gebruiken voor `twitchtracker_id`  gaat dat lastig, of wordt het anders heel slordig. Dan zouden we een aanpassingen moeten maken in de JSON. Lage prioriteit in ieder geval. Ik verwacht niet dat de mannen binnenkort naar Kick over zullen stappen.